### PR TITLE
[Feat/40]: 커피챗 리스트 불러오기 및 커피챗 디테일 정보 가져오기 기능 구현

### DIFF
--- a/app/coffeechat/info/[_id]/page.tsx
+++ b/app/coffeechat/info/[_id]/page.tsx
@@ -1,8 +1,11 @@
-const CoffeechatInfo = ({ params: { _id } }: { params: { _id: string } }) => {
+import CoffeechatInfo from '../../../../src/components/views/coffeechat/info/CoffeechatInfo';
+
+const CoffeechatInfoPage = ({ params: { _id } }: { params: { _id: string } }) => {
   return (
     <>
       <p>커피챗 상세 _id: {_id}</p>
+      <CoffeechatInfo _id={_id} />
     </>
   );
 };
-export default CoffeechatInfo;
+export default CoffeechatInfoPage;

--- a/app/coffeechat/layout.tsx
+++ b/app/coffeechat/layout.tsx
@@ -1,9 +1,16 @@
+'use client';
+import { QueryClientProvider, QueryClient } from 'react-query';
+
+const queryClient = new QueryClient();
+
 const Layout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <form>
-      <h2>Coffechat Layout</h2>
-      {children}
-    </form>
+    <QueryClientProvider client={queryClient}>
+      <form>
+        <h2>Coffechat Layout</h2>
+        {children}
+      </form>
+    </QueryClientProvider>
   );
 };
 

--- a/app/coffeechat/layout.tsx
+++ b/app/coffeechat/layout.tsx
@@ -3,7 +3,7 @@ import ReactQueryClient from '../../src/helper/utils/ReactQueryClient';
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <form>
+    <form className="border border-indigo-600">
       <h2>Coffechat Layout</h2>
       <ReactQueryClient>{children}</ReactQueryClient>
     </form>

--- a/app/coffeechat/layout.tsx
+++ b/app/coffeechat/layout.tsx
@@ -1,16 +1,12 @@
 'use client';
-import { QueryClientProvider, QueryClient } from 'react-query';
-
-const queryClient = new QueryClient();
+import ReactQueryClient from '../../src/helper/utils/ReactQueryClient';
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <QueryClientProvider client={queryClient}>
-      <form>
-        <h2>Coffechat Layout</h2>
-        {children}
-      </form>
-    </QueryClientProvider>
+    <form>
+      <h2>Coffechat Layout</h2>
+      <ReactQueryClient>{children}</ReactQueryClient>
+    </form>
   );
 };
 

--- a/app/coffeechat/page.tsx
+++ b/app/coffeechat/page.tsx
@@ -2,10 +2,10 @@ import CoffeechatLists from '../../src/components/views/coffeechat/CoffeechatLis
 
 const CoffeechatListPage = () => {
   return (
-    <>
+    <div className="border border-indigo-600">
       <h3>Coffeechat 홈</h3>
       <CoffeechatLists />
-    </>
+    </div>
   );
 };
 export default CoffeechatListPage;

--- a/app/coffeechat/page.tsx
+++ b/app/coffeechat/page.tsx
@@ -1,4 +1,11 @@
-const Coffeechat = () => {
-  return <h3>Coffeechat 홈</h3>;
+import CoffeechatLists from '../../src/components/views/coffeechat/CoffeechatLists';
+
+const CoffeechatListPage = () => {
+  return (
+    <>
+      <h3>Coffeechat 홈</h3>
+      <CoffeechatLists />
+    </>
+  );
 };
-export default Coffeechat;
+export default CoffeechatListPage;

--- a/src/components/views/coffeechat/CoffeechatLists.tsx
+++ b/src/components/views/coffeechat/CoffeechatLists.tsx
@@ -4,14 +4,14 @@ import Link from 'next/link';
 
 const CoffeechatLists = () => {
   const {
-    커피챗리스트데이터,
-    커피챗리스트데이터Loading,
-    커피챗리스트에러여부,
+    data: coffeechatListData,
+    loading: coffeechatListLoading,
+    isError: coffeechatListIsError,
   } = useSelectCoffeechatList();
 
-  if (커피챗리스트데이터Loading) return <></>;
-  if (커피챗리스트에러여부) {
-    return <div>Error: {커피챗리스트에러여부.message}</div>;
+  if (coffeechatListLoading) return <></>;
+  if (coffeechatListIsError) {
+    return <div>Error: {coffeechatListIsError.message}</div>;
   }
   return (
     <>
@@ -20,7 +20,7 @@ const CoffeechatLists = () => {
       <h1 className="text-xl font-bold mb-4 text-center">커피챗 전체 보기</h1>
       <div className="h-10" />
       <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-        {커피챗리스트데이터?.item.map(item => (
+        {coffeechatListData?.item.map(item => (
           <li key={item._id} className="bg-white p-4 rounded-lg shadow-md">
             <Link href={`coffeechat/info/${item._id}`}>
               <img

--- a/src/components/views/coffeechat/CoffeechatLists.tsx
+++ b/src/components/views/coffeechat/CoffeechatLists.tsx
@@ -1,5 +1,6 @@
 'use client';
 import useSelectCoffeechatList from '../../../queries/coffeechat/useSelectCoffeechatList';
+import Link from 'next/link';
 
 const CoffeechatLists = () => {
   const {
@@ -18,14 +19,16 @@ const CoffeechatLists = () => {
       <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
         {커피챗리스트데이터?.item.map(item => (
           <li key={item._id} className="bg-white p-4 rounded-lg shadow-md">
-            <img
-              src={item.mainImages}
-              alt="Coffee Image"
-              className="w-full h-32 object-cover mb-4 rounded-md"
-            />
-            <div className="text-lg font-bold mb-2">Title: {item.name}</div>
-            <div className="text-gray-600 mb-2">Author: {item.seller_id}</div>
-            <div className="text-gray-600">Category: {item.extra.category}</div>
+            <Link href={`coffeechat/info/${item._id}`}>
+              <img
+                src={item.mainImages}
+                alt="Coffee Image"
+                className="w-full h-32 object-cover mb-4 rounded-md"
+              />
+              <div className="text-lg font-bold mb-2">Title: {item.name}</div>
+              <div className="text-gray-600 mb-2">Author: {item.seller_id}</div>
+              <div className="text-gray-600">Category: {item.extra.category}</div>
+            </Link>
           </li>
         ))}
       </ul>

--- a/src/components/views/coffeechat/CoffeechatLists.tsx
+++ b/src/components/views/coffeechat/CoffeechatLists.tsx
@@ -1,0 +1,35 @@
+'use client';
+import useSelectCoffeechatList from '../../../queries/coffeechat/useSelectCoffeechatList';
+
+const CoffeechatLists = () => {
+  const {
+    커피챗리스트데이터,
+    커피챗리스트데이터Loading,
+    커피챗리스트에러여부,
+  } = useSelectCoffeechatList();
+
+  if (커피챗리스트데이터Loading) return <></>;
+  if (커피챗리스트에러여부) {
+    return <div>Error: {커피챗리스트에러여부.message}</div>;
+  }
+  return (
+    <>
+      <h1 className="text-3xl font-bold mb-4">이것은 커피챗 리스트</h1>
+      <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        {커피챗리스트데이터?.item.map(item => (
+          <li key={item._id} className="bg-white p-4 rounded-lg shadow-md">
+            <img
+              src={item.mainImages}
+              alt="Coffee Image"
+              className="w-full h-32 object-cover mb-4 rounded-md"
+            />
+            <div className="text-lg font-bold mb-2">Title: {item.name}</div>
+            <div className="text-gray-600 mb-2">Author: {item.seller_id}</div>
+            <div className="text-gray-600">Category: {item.extra.category}</div>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+};
+export default CoffeechatLists;

--- a/src/components/views/coffeechat/CoffeechatLists.tsx
+++ b/src/components/views/coffeechat/CoffeechatLists.tsx
@@ -15,7 +15,10 @@ const CoffeechatLists = () => {
   }
   return (
     <>
-      <h1 className="text-3xl font-bold mb-4">이것은 커피챗 리스트</h1>
+      <div className="h-60 bg-black text-white">광고중</div>
+      <div className="h-10"></div>
+      <h1 className="text-xl font-bold mb-4 text-center">커피챗 전체 보기</h1>
+      <div className="h-10" />
       <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
         {커피챗리스트데이터?.item.map(item => (
           <li key={item._id} className="bg-white p-4 rounded-lg shadow-md">

--- a/src/components/views/coffeechat/coffeechatList.tsx
+++ b/src/components/views/coffeechat/coffeechatList.tsx
@@ -1,4 +1,0 @@
-const coffeechatList = () => {
-  return <></>;
-};
-export default coffeechatList;

--- a/src/components/views/coffeechat/info/CoffeechatInfo.tsx
+++ b/src/components/views/coffeechat/info/CoffeechatInfo.tsx
@@ -4,14 +4,14 @@ import Link from 'next/link';
 
 const CoffeechatInfo = ({ _id }: { _id: string }) => {
   const {
-    커피챗디테일데이터,
-    커피챗디테일데이터Loading,
-    커피챗디테일에러여부,
+    data: coffeechatDetailData,
+    loading: coffeechatDetailLoading,
+    isError: coffeechatDetailIsError,
   } = useSelectCoffeechatInfo(_id);
 
-  if (커피챗디테일데이터Loading) return <></>;
-  if (커피챗디테일에러여부) {
-    return <div>Error: {커피챗디테일에러여부.message}</div>;
+  if (coffeechatDetailLoading) return <></>;
+  if (coffeechatDetailIsError) {
+    return <div>Error: {coffeechatDetailIsError.message}</div>;
   }
 
   return (
@@ -21,16 +21,16 @@ const CoffeechatInfo = ({ _id }: { _id: string }) => {
         <div className="flex flex-col md:flex-row">
           <div className="md:w-1/2 mb-4 md:mr-4">
             <img
-              src={커피챗디테일데이터?.item?.mainImages[0]}
-              alt={커피챗디테일데이터?.item?.name}
+              src={coffeechatDetailData?.item.mainImages[0]}
+              alt={coffeechatDetailData?.item.name}
               className="w-full h-auto"
             />
           </div>
           <div className="md:w-1/2">
-            <h3 className="text-lg font-bold mb-2">{커피챗디테일데이터.item.name}</h3>
-            <p className="mb-2">{커피챗디테일데이터?.item?.seller_id}</p>
+            <h3 className="text-lg font-bold mb-2">{coffeechatDetailData?.item.name}</h3>
+            <p className="mb-2">{coffeechatDetailData?.item.seller_id}</p>
             {/* 셀러 id로 셀러 정보 가져와서 프로필 이미지와 이름 정보 가져오기 */}
-            <p className="mb-2">{커피챗디테일데이터?.item?.extra?.category}</p>
+            <p className="mb-2">{coffeechatDetailData?.item.extra.category}</p>
           </div>
         </div>
         <div className="flex justify-between mt-4">
@@ -40,7 +40,7 @@ const CoffeechatInfo = ({ _id }: { _id: string }) => {
           </div>
           <div>
             <p className="text-lg font-bold">가격</p>
-            <p>{커피챗디테일데이터?.item?.price} 포인트</p>
+            <p>{coffeechatDetailData?.item.price} 포인트</p>
           </div>
         </div>
       </div>

--- a/src/components/views/coffeechat/info/CoffeechatInfo.tsx
+++ b/src/components/views/coffeechat/info/CoffeechatInfo.tsx
@@ -1,0 +1,26 @@
+'use client';
+import useSelectCoffeechatInfo from '../../../../queries/coffeechat/info/useSelectCoffeechatInfo';
+import Link from 'next/link';
+
+const CoffeechatInfo = ({ _id }: { _id: string }) => {
+  const {
+    커피챗디테일데이터,
+    커피챗디테일데이터Loading,
+    커피챗디테일에러여부,
+  } = useSelectCoffeechatInfo(_id);
+
+  if (커피챗디테일데이터Loading) return <></>;
+  if (커피챗디테일에러여부) {
+    return <div>Error: {커피챗디테일에러여부.message}</div>;
+  }
+
+  return (
+    <>
+      <h1 className="text-3xl font-bold mb-4">이것은 커피챗디테일</h1>
+      <img src={커피챗디테일데이터?.item?.mainImages} />
+      <div className="text-lg font-bold mb-2">Title: {커피챗디테일데이터.item.name}</div>
+    </>
+  );
+};
+
+export default CoffeechatInfo;

--- a/src/components/views/coffeechat/info/CoffeechatInfo.tsx
+++ b/src/components/views/coffeechat/info/CoffeechatInfo.tsx
@@ -16,9 +16,34 @@ const CoffeechatInfo = ({ _id }: { _id: string }) => {
 
   return (
     <>
-      <h1 className="text-3xl font-bold mb-4">이것은 커피챗디테일</h1>
-      <img src={커피챗디테일데이터?.item?.mainImages} />
-      <div className="text-lg font-bold mb-2">Title: {커피챗디테일데이터.item.name}</div>
+      <div className="max-w-2xl mx-auto p-4">
+        <h1 className="text-3xl font-bold mb-4">이것은 커피챗디테일</h1>
+        <div className="flex flex-col md:flex-row">
+          <div className="md:w-1/2 mb-4 md:mr-4">
+            <img
+              src={커피챗디테일데이터?.item?.mainImages[0]}
+              alt={커피챗디테일데이터?.item?.name}
+              className="w-full h-auto"
+            />
+          </div>
+          <div className="md:w-1/2">
+            <h3 className="text-lg font-bold mb-2">{커피챗디테일데이터.item.name}</h3>
+            <p className="mb-2">{커피챗디테일데이터?.item?.seller_id}</p>
+            {/* 셀러 id로 셀러 정보 가져와서 프로필 이미지와 이름 정보 가져오기 */}
+            <p className="mb-2">{커피챗디테일데이터?.item?.extra?.category}</p>
+          </div>
+        </div>
+        <div className="flex justify-between mt-4">
+          <div>
+            <p className="text-lg font-bold">후기</p>
+            {/* 후기 내용 표시 */}
+          </div>
+          <div>
+            <p className="text-lg font-bold">가격</p>
+            <p>{커피챗디테일데이터?.item?.price} 포인트</p>
+          </div>
+        </div>
+      </div>
     </>
   );
 };

--- a/src/queries/coffeechat/info/useSelectCoffeechatInfo.tsx
+++ b/src/queries/coffeechat/info/useSelectCoffeechatInfo.tsx
@@ -1,18 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 
-const 커피챗디테일반환 = async (_id: string) => {
-  const response = await axios.get(`https://localhost/api/products/${_id}`);
+const BASE_URL = process.env.NEXT_PUBLIC_EDUTUBE_API;
+const URL = '/products';
+
+const axiosGet = async (_id: string) => {
+  const response = await axios.get(BASE_URL + URL + `/${_id}`);
   return response.data;
 };
 
 const useSelectCoffeechatInfo = (_id: string) => {
-  const {
-    data: 커피챗디테일데이터,
-    isLoading: 커피챗디테일데이터Loading,
-    isError: 커피챗디테일에러여부,
-  } = useQuery({ queryKey: ['커피챗디테일'], queryFn: () => 커피챗디테일반환(_id) });
-  return { 커피챗디테일데이터, 커피챗디테일데이터Loading, 커피챗디테일에러여부 };
+  return useQuery({ queryKey: ['coffeechatDetail'], queryFn: () => axiosGet(_id) });
 };
 
 export default useSelectCoffeechatInfo;

--- a/src/queries/coffeechat/info/useSelectCoffeechatInfo.tsx
+++ b/src/queries/coffeechat/info/useSelectCoffeechatInfo.tsx
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+
+const 커피챗디테일반환 = async (_id: string) => {
+  const response = await axios.get(`https://localhost/api/products/${_id}`);
+  return response.data;
+};
+
+const useSelectCoffeechatInfo = (_id: string) => {
+  const {
+    data: 커피챗디테일데이터,
+    isLoading: 커피챗디테일데이터Loading,
+    isError: 커피챗디테일에러여부,
+  } = useQuery({ queryKey: ['커피챗디테일'], queryFn: () => 커피챗디테일반환(_id) });
+  return { 커피챗디테일데이터, 커피챗디테일데이터Loading, 커피챗디테일에러여부 };
+};
+
+export default useSelectCoffeechatInfo;

--- a/src/queries/coffeechat/useSelectCoffeechatList.ts
+++ b/src/queries/coffeechat/useSelectCoffeechatList.ts
@@ -1,19 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 
-const API_ENDPOINT = 'https://localhost/api/products';
+const BASE_URL = process.env.NEXT_PUBLIC_EDUTUBE_API;
+const URL = '/products';
 
-const 커피챗리스트반환 = async () => {
-  const response = await axios.get(API_ENDPOINT);
+const axiosGet = async () => {
+  const response = await axios.get(BASE_URL + URL);
   return response.data;
 };
 
 const useSelectCoffeechatList = () => {
-  const {
-    data: 커피챗리스트데이터,
-    isLoading: 커피챗리스트데이터Loading,
-    isError: 커피챗리스트에러여부,
-  } = useQuery({ queryKey: ['커피챗리스트'], queryFn: 커피챗리스트반환 });
-  return { 커피챗리스트데이터, 커피챗리스트데이터Loading, 커피챗리스트에러여부 };
+  return useQuery({ queryKey: ['coffeechatList'], queryFn: axiosGet });
 };
+
 export default useSelectCoffeechatList;

--- a/src/queries/coffeechat/useSelectCoffeechatList.ts
+++ b/src/queries/coffeechat/useSelectCoffeechatList.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+
+const API_ENDPOINT = 'https://localhost/api/products';
+
+const 커피챗리스트반환 = async () => {
+  const response = await axios.get(API_ENDPOINT);
+  return response.data;
+};
+
+const useSelectCoffeechatList = () => {
+  const {
+    data: 커피챗리스트데이터,
+    isLoading: 커피챗리스트데이터Loading,
+    isError: 커피챗리스트에러여부,
+  } = useQuery({ queryKey: ['커피챗리스트'], queryFn: 커피챗리스트반환 });
+  return { 커피챗리스트데이터, 커피챗리스트데이터Loading, 커피챗리스트에러여부 };
+};
+export default useSelectCoffeechatList;


### PR DESCRIPTION
## ✨ 구현기능 

- 커피챗 상세목록 라우터 연결하기, 간단한 CSS 작업
- 커피쳇 상세목록 보여주기, 간단한 CSS 작업
- 전체 레이아웃 반응형에 따라 padding 값 지정하기, 임시로 border값 설정하기
```javascript
div className="border-8 border-indigo-600 px-6 sm:px-8 md:px-12 lg:px-14 2xl:px-80 pb-28">
```
<img width="575" alt="스크린샷 2023-11-28 오후 5 47 16" src="https://github.com/FESPfinal/EDUTUBE/assets/78894678/fb41ce23-8296-4eb9-9921-7b9f8004fbe4">


<br>

## 👀 구현한 기능에 대한 gif 

-

<br>

## 🙏 To Reviewers 🙏

- query에 작성한 useQuery와 axios 코드 스타일 많이 봐주셨으면 좋겠어요.
- 저희가 아직 서버 통신에 관련한 코드 컨벤션이 없어서 이번에 이걸 올리면서 잡고 가야할 것 같아서 더 깔끔하거나 더 좋은 아이디어 있으시면 제시 부탁드립니다. 아니면 제가 한거 그대로 가도 좋다는 아이디어도 좋아요^^

아 그리고 디테일 페이지로 이동할 때 id를 4번의 인자를 거의 props driling 처럼 이동하게 되는데 이렇게 하는게 괜찮을지도 의견 궁금해요.
query에서 params를 가져오려고 하니 잘 안돼서요. 고민입니다. 일단 기능 동작은 잘 됩니다.

