### PR TITLE
[Feat/50]: 결제하기 기능 구현

### DIFF
--- a/app/mypage/purchase/page.tsx
+++ b/app/mypage/purchase/page.tsx
@@ -1,0 +1,8 @@
+const MypagePurchase = () => {
+  return (
+    <>
+      <p>내 커피챗 구매 목록</p>
+    </>
+  );
+};
+export default MypagePurchase;

--- a/src/components/views/coffeechat/info/CoffeechatInfo.tsx
+++ b/src/components/views/coffeechat/info/CoffeechatInfo.tsx
@@ -32,7 +32,7 @@ const CoffeechatInfo = ({ _id }: { _id: string }) => {
     mutateOrderCoffeechat(product, {
       onSuccess: data => {
         alert(`주문이 완료되었습니다.`);
-        router.push('/mypage/purchases');
+        router.push('/mypage/purchase');
       },
       onError: error => {
         if (error.message == 'authToken is not defined') {

--- a/src/components/views/coffeechat/info/CoffeechatInfo.tsx
+++ b/src/components/views/coffeechat/info/CoffeechatInfo.tsx
@@ -24,8 +24,8 @@ const CoffeechatInfo = ({ _id }: { _id: string }) => {
         },
       ],
       address: {
-        name: '학교',
-        value: '서울시 강남구 역삼동 234',
+        name: '',
+        value: '',
       },
     };
 

--- a/src/components/views/coffeechat/info/CoffeechatInfo.tsx
+++ b/src/components/views/coffeechat/info/CoffeechatInfo.tsx
@@ -1,13 +1,48 @@
 'use client';
 import useSelectCoffeechatInfo from '../../../../queries/coffeechat/info/useSelectCoffeechatInfo';
-import Link from 'next/link';
+import useUpdateOrder from '../../../../queries/coffeechat/order/useUpdateOrder';
+import Button from '../../../atom/Button';
+import { IOrderDataType } from '../../../../helper/types/order';
+import { useRouter } from 'next/navigation';
 
 const CoffeechatInfo = ({ _id }: { _id: string }) => {
+  const router = useRouter();
   const {
     data: coffeechatDetailData,
     loading: coffeechatDetailLoading,
     isError: coffeechatDetailIsError,
   } = useSelectCoffeechatInfo(_id);
+
+  const { mutate: mutateOrderCoffeechat } = useUpdateOrder();
+
+  const orderCoffeechat = (_id: number) => {
+    const product: IOrderDataType = {
+      products: [
+        {
+          _id: _id,
+          quantity: 1,
+        },
+      ],
+      address: {
+        name: '학교',
+        value: '서울시 강남구 역삼동 234',
+      },
+    };
+
+    mutateOrderCoffeechat(product, {
+      onSuccess: data => {
+        alert(`주문이 완료되었습니다.`);
+      },
+      onError: error => {
+        if (error.message == 'authToken is not defined') {
+          alert(`로그인 이후에 결제가 가능합니다.`);
+          router.push('/login');
+        } else {
+          alert(`주문에 실패하셨습니다. ${error.message}`);
+        }
+      },
+    });
+  };
 
   if (coffeechatDetailLoading) return <></>;
   if (coffeechatDetailIsError) {
@@ -30,6 +65,11 @@ const CoffeechatInfo = ({ _id }: { _id: string }) => {
             <h3 className="text-lg font-bold mb-2">{coffeechatDetailData?.item.name}</h3>
             <p className="mb-2">{coffeechatDetailData?.item.seller_id}</p>
             {/* 셀러 id로 셀러 정보 가져와서 프로필 이미지와 이름 정보 가져오기 */}
+            <Button
+              content="결제하기"
+              size="medium"
+              onClick={() => orderCoffeechat(parseInt(_id))}
+            />
             <p className="mb-2">{coffeechatDetailData?.item.extra.category}</p>
           </div>
         </div>

--- a/src/components/views/coffeechat/info/CoffeechatInfo.tsx
+++ b/src/components/views/coffeechat/info/CoffeechatInfo.tsx
@@ -32,6 +32,7 @@ const CoffeechatInfo = ({ _id }: { _id: string }) => {
     mutateOrderCoffeechat(product, {
       onSuccess: data => {
         alert(`주문이 완료되었습니다.`);
+        router.push('/mypage/purchases');
       },
       onError: error => {
         if (error.message == 'authToken is not defined') {

--- a/src/helper/types/order.ts
+++ b/src/helper/types/order.ts
@@ -1,0 +1,14 @@
+export interface ProductType {
+  _id: number;
+  quantity: number;
+}
+
+export interface AddressType {
+  name: string;
+  value: string;
+}
+
+export interface IOrderDataType {
+  products: ProductType[];
+  address: AddressType;
+}

--- a/src/queries/coffeechat/order/useUpdateOrder.tsx
+++ b/src/queries/coffeechat/order/useUpdateOrder.tsx
@@ -1,0 +1,26 @@
+import { useMutation } from '@tanstack/react-query';
+import axios from 'axios';
+import { IOrderDataType } from '../../../helper/types/order';
+
+const BASE_URL = process.env.NEXT_PUBLIC_EDUTUBE_API;
+const URL = '/orders';
+
+//[TODO] authToken 값 자동으로 가져오게 코드 구현하기
+const axiosPost = async (orderData: IOrderDataType) => {
+  // const authToken =
+  //   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJfaWQiOjQsInR5cGUiOiJ1c2VyIiwiaWF0IjoxNzAxMjM2MTA5LCJleHAiOjE3MDEyNDMzMDksImlzcyI6IkZFU1AwMSJ9.eDqUVujFXN9UW8vEOJMmKh-Qt9v8ZOzmOR8TQ8z4e-g';
+  const response = await axios.post(BASE_URL + URL, orderData, {
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+    },
+  });
+  return response.data;
+};
+
+const useUpdateOrder = () => {
+  return useMutation({
+    mutationFn: (orderData: IOrderDataType) => axiosPost(orderData),
+  });
+};
+
+export default useUpdateOrder;


### PR DESCRIPTION
## ✨ 구현기능 

- 커피챗 디테일 페이지에서 결제하기 버튼 구현하였습니다.
- 버튼 클릭 시에 로그인이 안되어 있으면 alert창이 뜨고 로그인 페이지로 이동하게 구현
- 로그인이 되어있으면 결제가 완료 되고 alert창이 뜨는 것으로 구현하였습니다.
- address는 기본 값으로 비어있는 값을 넣었습니다.

<br>

## 👀 구현한 기능에 대한 gif 

-
![order](https://github.com/FESPfinal/EDUTUBE/assets/78894678/1edd7a03-59d8-42dc-aaaa-75810f96bfdb)


<br>

## 🙏 To Reviewers 🙏

- 토큰은 직접 가져와서 넣어야 되는 코드로 임시로 작성하였습니다. 추후에 민경님께서 로그인 기능 구현하시면 자동으로 처리 되도록 수정 작업 할 예정입니다.

- 원래는 기획대로 시간을 선택해서 예약 모달창을 추가해야하나 1차 발표 전에 임시로 빠르게 작업이 필요할 것 같아 기본적인 결제하기 기능만 구현하였습니다. 12월 1일 발표 이후에 경석님께서 캘린더 라이브러리 작업하시면서 수정하시면 될 것 같습니다!

- 여러곳에서 동일한 producttype(주문한 내역 관련 타입)을 사용하여 제가 helper 폴더 내부에 types폴더 만들어서 order.type을 생성하였습니다. 다른 분들도 타입 저장하실 때 여기에 저장해서 사용하시면 될 것 같습니다.

close #50 