### PR TITLE
[Feat/66] 구매 목록 불러오기 기능 구현

### DIFF
--- a/app/mypage/layout.tsx
+++ b/app/mypage/layout.tsx
@@ -1,8 +1,9 @@
+import ReactQueryClient from '../../src/helper/utils/ReactQueryClient';
+
 const Layout = ({ children }: { children: React.ReactNode }) => {
   return (
     <form>
-      <h2>Mypage Layout</h2>
-      {children}
+      <ReactQueryClient> {children}</ReactQueryClient>
     </form>
   );
 };

--- a/app/mypage/purchase/page.tsx
+++ b/app/mypage/purchase/page.tsx
@@ -1,8 +1,10 @@
-const MypagePurchase = () => {
+import PurchaseList from '../../../src/components/views/mypage/purchase/PurchaseList';
+
+const MypagePurchasePage = () => {
   return (
     <>
-      <p>내 커피챗 구매 목록</p>
+      <PurchaseList />
     </>
   );
 };
-export default MypagePurchase;
+export default MypagePurchasePage;

--- a/src/components/views/mypage/purchase/PurchaseList.tsx
+++ b/src/components/views/mypage/purchase/PurchaseList.tsx
@@ -1,0 +1,27 @@
+'use client';
+import useSelectOrder from '../../../../queries/coffeechat/order/useSelectOrder';
+
+const PurchaseList = () => {
+  const { data: purchaseListData } = useSelectOrder();
+
+  return (
+    <>
+      <h1 className="text-2xl font-bold mb-4">커피챗 구매 목록 리스트</h1>
+      <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        {purchaseListData?.item.map(item => (
+          <li key={item._id} className="bg-white p-4 rounded-md shadow-md">
+            <img
+              src={item.products[0].image}
+              alt={item.products[0].name}
+              className="w-full h-32 object-cover mb-4 rounded-md"
+            />
+            <p className="text-lg font-bold mb-2">제목: {item.products[0].name}</p>
+            <p className="mb-2">가격: {item.products[0].price}원</p>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+};
+
+export default PurchaseList;

--- a/src/queries/coffeechat/order/useSelectOrder.ts
+++ b/src/queries/coffeechat/order/useSelectOrder.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+import Cookies from 'js-cookie';
+
+const BASE_URL = process.env.NEXT_PUBLIC_EDUTUBE_API;
+const URL = '/orders';
+
+const axiosGet = async () => {
+  const accessToken = Cookies.get('accessToken');
+  const response = await axios.post(BASE_URL + URL, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+  return response.data;
+};
+const useSelectOrder = () => {
+  return useQuery({ queryKey: ['orderList'], queryFn: axiosGet });
+};

--- a/src/queries/coffeechat/order/useSelectOrder.ts
+++ b/src/queries/coffeechat/order/useSelectOrder.ts
@@ -1,3 +1,4 @@
+'use client';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import Cookies from 'js-cookie';
@@ -7,7 +8,7 @@ const URL = '/orders';
 
 const axiosGet = async () => {
   const accessToken = Cookies.get('accessToken');
-  const response = await axios.post(BASE_URL + URL, {
+  const response = await axios.get(BASE_URL + URL, {
     headers: {
       Authorization: `Bearer ${accessToken}`,
     },
@@ -17,3 +18,5 @@ const axiosGet = async () => {
 const useSelectOrder = () => {
   return useQuery({ queryKey: ['orderList'], queryFn: axiosGet });
 };
+
+export default useSelectOrder;


### PR DESCRIPTION
## ✨ 구현기능 

- 구매 목록 불러오기 기능 구현
mypage/purchase 라우터에 페이지 추가

<br>

## 👀 구현한 기능에 대한 gif 

-
![스크린샷 2023-12-01 오전 1 01 15](https://github.com/FESPfinal/EDUTUBE/assets/78894678/e21ffd5c-6a11-4114-9600-6c1a0af0ba4c)


<br>

## 🙏 To Reviewers 🙏

- 추가적으로 리스트 요소를 하나 클릭하면 해당하는 디테일 페이지로 이동하고 싶은데 현재 라우터가 mypage/purchase 여서
이동시에 mypage/coffeechat/info/id 이런식으로 이동되어서 404가 뜨네요 ! 그래서 일단 링크 기능은 안넣었는데 고민입니다!

