### PR TITLE
[Feat/95]: axios interceptor 구현 및 refresh Token 수정, userInfo zustand에 설정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "react-query": "^3.39.3",
         "styled-components": "^6.1.1",
         "yup": "^1.3.2",
-        "zustand": "^4.4.6"
+        "zustand": "^4.4.7",
+        "zustand-persist": "^0.4.0"
       },
       "devDependencies": {
         "@svgr/webpack": "^8.1.0",
@@ -8278,9 +8279,9 @@
       }
     },
     "node_modules/zustand": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.6.tgz",
-      "integrity": "sha512-Rb16eW55gqL4W2XZpJh0fnrATxYEG3Apl2gfHTyDSE965x/zxslTikpNch0JgNjJA9zK6gEFW8Fl6d1rTZaqgg==",
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.7.tgz",
+      "integrity": "sha512-QFJWJMdlETcI69paJwhSMJz7PPWjVP8Sjhclxmxmxv/RYI7ZOvR5BHX+ktH0we9gTWQMxcne8q1OY8xxz604gw==",
       "dependencies": {
         "use-sync-external-store": "1.2.0"
       },
@@ -8302,6 +8303,15 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zustand-persist": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/zustand-persist/-/zustand-persist-0.4.0.tgz",
+      "integrity": "sha512-u6bBIc4yZRpSKBKuTNhoqvoIb09gGHk2NkiPg4K7MPIWTYZg70PlpBn48QEDnKZwfNurnf58TaW5BuMGIMf5hw==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "zustand": ">=3.6.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react-query": "^3.39.3",
     "styled-components": "^6.1.1",
     "yup": "^1.3.2",
-    "zustand": "^4.4.6"
+    "zustand": "^4.4.7",
+    "zustand-persist": "^0.4.0"
   },
   "devDependencies": {
     "@svgr/webpack": "^8.1.0",

--- a/src/components/block/navbar/NavLogoutModal.tsx
+++ b/src/components/block/navbar/NavLogoutModal.tsx
@@ -2,12 +2,15 @@
 
 import Link from 'next/link';
 import Cookies from 'js-cookie';
-import { useRouter, redirect } from 'next/navigation';
+import { useRouter } from 'next/navigation';
+import useUserInfo from '@/stores/userInfo';
 
 const NavLogoutModal = () => {
+  const { deleteUserInfo } = useUserInfo(store => store);
   const router = useRouter();
 
   const handleLogout = () => {
+    deleteUserInfo();
     Cookies.remove('accessToken');
     Cookies.remove('refreshToken');
     Cookies.remove('user_id');

--- a/src/components/views/login/Login.tsx
+++ b/src/components/views/login/Login.tsx
@@ -34,7 +34,6 @@ const Login = () => {
       {
         onSuccess: data => {
           Cookies.set('accessToken', data.token.accessToken);
-          Cookies.set('refreshToken', data.token.refreshToken);
           Cookies.set('user_id', String(data._id));
           Cookies.set('user_name', data.name);
           router.push('/');

--- a/src/components/views/mypage/MypageInfo.tsx
+++ b/src/components/views/mypage/MypageInfo.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import useSelectMemberInfo from '@/queries/member/useSelectMemberInfo';
 import MypageSellerInfo from './MypageSellerInfo';
 import MypageUserInfo from './MypageUserInfo';
+import useUserInfo from '@/stores/userInfo';
 
 const MypageInfo = () => {
-  const { data } = useSelectMemberInfo('type');
-  const isUser = data?.type === 'user' ? true : false;
+  const { userInfo } = useUserInfo(store => store);
+  const isUser = userInfo.type === 'user' ? true : false;
   return (
     <div className="m-5 ml-8">
       <p className="text-3xl my-10">내 정보</p>

--- a/src/components/views/mypage/MypageMenu.tsx
+++ b/src/components/views/mypage/MypageMenu.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import useSelectMemberInfo from '@/queries/member/useSelectMemberInfo';
+import useUserInfo from '@/stores/userInfo';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 
 const userMenuList = [
   { title: '찜', link: '/mypage/likes' },
@@ -22,24 +23,33 @@ const sellerMenuList = [
 ];
 
 const MypageMenu = () => {
-  const { data: memberType } = useSelectMemberInfo('type');
-  const userType = memberType?.type;
+  const [isClient, setIsClient] = useState(false);
 
-  const menuList = userType === 'seller' ? sellerMenuList : userMenuList;
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  const { userInfo } = useUserInfo(store => store);
+
+  const menuList = userInfo?.type === 'seller' ? sellerMenuList : userMenuList;
 
   return (
     <div className="flex flex-col bg-white w-80 h-screen pt-5 shadow-[8px_0_10px_-5px_rgba(0,0,0,0.3)]">
-      <ul>
-        {menuList.map(menu => {
-          return (
-            <li key={menu.link} className="mb-2 py-1 px-3 text-gray-600 hover:bg-gray-200 ">
-              <Link href={menu.link}>
-                <span className="text-l">{menu.title}</span>
-              </Link>
-            </li>
-          );
-        })}
-      </ul>
+      {isClient ? (
+        <ul>
+          {menuList.map(menu => {
+            return (
+              <li key={menu.link} className="mb-2 py-1 px-3 text-gray-600 hover:bg-gray-200 ">
+                <Link href={menu.link}>
+                  <span className="text-l">{menu.title}</span>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      ) : (
+        <>Loading...</>
+      )}
     </div>
   );
 };

--- a/src/components/views/sign-up/SignUp.tsx
+++ b/src/components/views/sign-up/SignUp.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import SignUpIdPw from './SignUpIdPw';
 import SignUpUserInfo from './SignUpUserInfo';
-import { Step1Data, Step2UserData } from '../../../helper/types/userInfoTypes';
+import { Step1Data } from '../../../helper/types/userInfo';
 import { USER_TYPES } from '../../../helper/constants/userConst';
 import useCreateUser, { SignUpData } from '@/queries/signUp/useCreateUser';
 import SignUpSellerInfo from './SignUpSellerInfo';
@@ -17,17 +17,6 @@ type DefaultUserData = {
   address: string;
   type: string;
 };
-
-type UserData = {
-  extra: {
-    profileImage: File | undefined;
-    major: string;
-    contactEmail: string;
-    profile: string;
-  };
-} & DefaultUserData;
-
-type SellerData = {};
 
 const STEPS = {
   STEP1: 1,

--- a/src/components/views/sign-up/SignUpIdPw.tsx
+++ b/src/components/views/sign-up/SignUpIdPw.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 import { USER_TYPES } from '../../../helper/constants/userConst';
-import { Step1Data } from '../../../helper/types/userInfoTypes';
+import { Step1Data } from '../../../helper/types/userInfo';
 import { AxiosError } from 'axios';
 
 const schema = yup.object().shape({

--- a/src/components/views/sign-up/SignUpSellerInfo.tsx
+++ b/src/components/views/sign-up/SignUpSellerInfo.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as yup from 'yup';
-import { Step1Data } from '../../../helper/types/userInfoTypes';
+import { Step1Data } from '../../../helper/types/userInfo';
 import ProfileImageUploader from '@/components/atom/ProfileImageUploader';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';

--- a/src/components/views/sign-up/SignUpUserInfo.tsx
+++ b/src/components/views/sign-up/SignUpUserInfo.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 import { USER_TYPES } from '../../../helper/constants/userConst';
-import { Step1Data } from '../../../helper/types/userInfoTypes';
+import { Step1Data } from '../../../helper/types/userInfo';
 import useCreateUser from '@/queries/signUp/useCreateUser';
 import { useRouter } from 'next/navigation';
 import useCreateFile from '@/queries/common/useCreateFile';

--- a/src/helper/types/userInfo.ts
+++ b/src/helper/types/userInfo.ts
@@ -16,3 +16,19 @@ export type Step2UserData = {
     major: string;
   };
 };
+
+export type UserItem = {
+  _id: number;
+  email: string;
+  name: string;
+  phone: string;
+  address: string;
+  type: string;
+  createdAt: string;
+  updatedAt: string;
+  extra: {};
+  token: {
+    accessToken: string;
+    refreshToken: string;
+  };
+};

--- a/src/helper/utils/useEdutubeAxios.ts
+++ b/src/helper/utils/useEdutubeAxios.ts
@@ -1,0 +1,45 @@
+import axios, { AxiosResponse } from 'axios';
+import { BASE_URL } from '../constants/apiConst';
+import useAuth from '@/stores/auth';
+import Cookies from 'js-cookie';
+
+const useEdutubeAxios = () => {
+  const { accessToken } = useAuth(store => store);
+  const refreshToken = Cookies.get('refreshToken');
+
+  const edutubeAxios = axios.create({
+    baseURL: BASE_URL,
+    timeout: 1000,
+  });
+
+  /** 1. 요청 전 - access토큰있는데 만료되면 refresh토큰도 헤더담아서 요청보내기 */
+  edutubeAxios.interceptors.request.use(
+    config => {
+      if (accessToken) {
+        config.headers.Authorization = `Bearer ${accessToken}`;
+      }
+      return config;
+    },
+    error => Promise.reject(error),
+  );
+
+  /** 4. 응답 전 - 새 access토큰받으면 갈아끼기 */
+  // edutubeAxios.interceptors.response.use(
+  //   async (response: AxiosResponse) => {
+  //     if (response.headers.authorization) {
+  //       const newAccessToken = response?.headers?.authorization;
+  //       deleteAccessToken(); // 만료된 access토큰 삭제
+  //       setAccessToken(newAccessToken); // 새걸로 교체
+  //       response.config.headers.Authorization = `${newAccessToken}`;
+  //     }
+  //     return response;
+  //   },
+  //   error => {
+  //     //응답 200 아닌 경우 - 디버깅
+  //     return Promise.reject(error);
+  //   },
+  // );
+
+  return { edutubeAxios };
+};
+export default useEdutubeAxios;

--- a/src/queries/auth/useRefreshToken.ts
+++ b/src/queries/auth/useRefreshToken.ts
@@ -1,0 +1,10 @@
+import axios from 'axios';
+import Cookies from 'js-cookie';
+
+const BASE_URL = process.env.NEXT_PUBLIC_EDUTUBE_API;
+const URL = '/users/refresh';
+
+const useRefreshToken = async () => {
+  const refreshToken = Cookies.get('refreshToken');
+  return await axios.get(BASE_URL + URL, { headers: { Authorization: `Bearer ${refreshToken}` } });
+};

--- a/src/queries/auth/useRefreshToken.ts
+++ b/src/queries/auth/useRefreshToken.ts
@@ -8,3 +8,5 @@ const useRefreshToken = async () => {
   const refreshToken = Cookies.get('refreshToken');
   return await axios.get(BASE_URL + URL, { headers: { Authorization: `Bearer ${refreshToken}` } });
 };
+
+export default useRefreshToken;

--- a/src/queries/login/useLogin.ts
+++ b/src/queries/login/useLogin.ts
@@ -1,9 +1,11 @@
 'use client';
 
 import { UserItem } from '@/helper/types/userInfo';
+import useAuth from '@/stores/auth';
 import useUserInfo from '@/stores/userInfo';
 import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
+import Cookies from 'js-cookie';
 
 type LoginData = {
   email: string;
@@ -15,10 +17,12 @@ const URL = '/users/login';
 
 const useLogin = () => {
   const { setUserInfo } = useUserInfo(state => state);
+  const { setAccessToken } = useAuth(store => store);
 
   const axiosPost = async (data: LoginData) => {
     const response = await axios.post(BASE_URL + URL, data);
     const item = await response.data.item;
+    setAccessToken(await item.token.accessToken);
     setUserInfo({
       _id: await item._id,
       email: await item.email,
@@ -30,6 +34,7 @@ const useLogin = () => {
       updatedAt: await item.updatedAt,
       extra: await item.extra,
     });
+    Cookies.set('refreshToken', await item.token.refreshToken);
     return (await item) as UserItem;
   };
 

--- a/src/queries/login/useLogin.ts
+++ b/src/queries/login/useLogin.ts
@@ -5,7 +5,6 @@ import useEdutubeAxios from '@/helper/utils/useEdutubeAxios';
 import useAuth from '@/stores/auth';
 import useUserInfo from '@/stores/userInfo';
 import { useMutation } from '@tanstack/react-query';
-import axios from 'axios';
 import Cookies from 'js-cookie';
 
 type LoginData = {

--- a/src/queries/login/useLogin.ts
+++ b/src/queries/login/useLogin.ts
@@ -1,5 +1,7 @@
 'use client';
 
+import { UserItem } from '@/helper/types/userInfo';
+import useUserInfo from '@/stores/userInfo';
 import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 
@@ -8,31 +10,29 @@ type LoginData = {
   password: string;
 };
 
-type UserItem = {
-  _id: number;
-  email: string;
-  name: string;
-  phone: string;
-  address: string;
-  type: string;
-  createdAt: string;
-  updatedAt: string;
-  extra: {};
-  token: {
-    accessToken: string;
-    refreshToken: string;
-  };
-};
-
 const BASE_URL = process.env.NEXT_PUBLIC_EDUTUBE_API;
 const URL = '/users/login';
 
-const axiosPost = async (data: LoginData) => {
-  const response = await axios.post(BASE_URL + URL, data);
-  return response.data.item as UserItem;
-};
-
 const useLogin = () => {
+  const { setUserInfo } = useUserInfo(state => state);
+
+  const axiosPost = async (data: LoginData) => {
+    const response = await axios.post(BASE_URL + URL, data);
+    const item = await response.data.item;
+    setUserInfo({
+      _id: await item._id,
+      email: await item.email,
+      name: await item.name,
+      phone: await item.phone,
+      address: await item.address,
+      type: await item.type,
+      createdAt: await item.createdAt,
+      updatedAt: await item.updatedAt,
+      extra: await item.extra,
+    });
+    return (await item) as UserItem;
+  };
+
   return useMutation({ mutationFn: (data: LoginData) => axiosPost(data) });
 };
 

--- a/src/queries/login/useLogin.ts
+++ b/src/queries/login/useLogin.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { UserItem } from '@/helper/types/userInfo';
+import useEdutubeAxios from '@/helper/utils/useEdutubeAxios';
 import useAuth from '@/stores/auth';
 import useUserInfo from '@/stores/userInfo';
 import { useMutation } from '@tanstack/react-query';
@@ -12,15 +13,16 @@ type LoginData = {
   password: string;
 };
 
-const BASE_URL = process.env.NEXT_PUBLIC_EDUTUBE_API;
 const URL = '/users/login';
 
 const useLogin = () => {
-  const { setUserInfo } = useUserInfo(state => state);
+  const { edutubeAxios } = useEdutubeAxios();
+
+  const { setUserInfo } = useUserInfo(store => store);
   const { setAccessToken } = useAuth(store => store);
 
   const axiosPost = async (data: LoginData) => {
-    const response = await axios.post(BASE_URL + URL, data);
+    const response = await edutubeAxios.post(URL, data);
     const item = await response.data.item;
     setAccessToken(await item.token.accessToken);
     setUserInfo({

--- a/src/queries/mypage/useSelectUserInfo.ts
+++ b/src/queries/mypage/useSelectUserInfo.ts
@@ -1,19 +1,17 @@
 'use client';
 
 import useEdutubeAxios from '@/helper/utils/useEdutubeAxios';
+import useUserInfo from '@/stores/userInfo';
 import { useQuery } from '@tanstack/react-query';
-import axios from 'axios';
-import Cookies from 'js-cookie';
 
-const user_id = Cookies.get('user_id');
-
-const URL = `/users/${user_id}`;
+const URL = (user_id: number) => `/users/${user_id}`;
 
 const useSelectUserInfo = () => {
   const { edutubeAxios } = useEdutubeAxios();
+  const { userInfo } = useUserInfo(store => store);
 
   const axiosGet = async () => {
-    const response = await edutubeAxios.get(URL);
+    const response = await edutubeAxios.get(URL(userInfo._id));
     return response.data.item;
   };
 

--- a/src/queries/mypage/useSelectUserInfo.ts
+++ b/src/queries/mypage/useSelectUserInfo.ts
@@ -6,13 +6,12 @@ import axios from 'axios';
 import Cookies from 'js-cookie';
 
 const user_id = Cookies.get('user_id');
-const accessToken = Cookies.get('accessToken');
 
-const BASE_URL = process.env.NEXT_PUBLIC_EDUTUBE_API;
 const URL = `/users/${user_id}`;
 
 const useSelectUserInfo = () => {
   const { edutubeAxios } = useEdutubeAxios();
+
   const axiosGet = async () => {
     const response = await edutubeAxios.get(URL);
     return response.data.item;

--- a/src/queries/mypage/useSelectUserInfo.ts
+++ b/src/queries/mypage/useSelectUserInfo.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import useEdutubeAxios from '@/helper/utils/useEdutubeAxios';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import Cookies from 'js-cookie';
@@ -11,12 +12,9 @@ const BASE_URL = process.env.NEXT_PUBLIC_EDUTUBE_API;
 const URL = `/users/${user_id}`;
 
 const useSelectUserInfo = () => {
+  const { edutubeAxios } = useEdutubeAxios();
   const axiosGet = async () => {
-    const response = await axios.get(BASE_URL + URL, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
+    const response = await edutubeAxios.get(URL);
     return response.data.item;
   };
 

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,0 +1,9 @@
+import { create } from 'zustand';
+
+const useAuth = create(set => ({
+  accessToken: '',
+  setAccessToken: (token: string) => set({ token }),
+  deleteUserInfo: () => set({ accessToken: '' }),
+}));
+
+export default useAuth;

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,9 +1,17 @@
 import { create } from 'zustand';
 
-const useAuth = create(set => ({
+type Auth = {
+  accessToken: string;
+  setAccessToken: (token: string) => void;
+  deleteAccessToken: () => void;
+};
+
+const useAuth = create<Auth>(set => ({
   accessToken: '',
-  setAccessToken: (token: string) => set({ token }),
-  deleteUserInfo: () => set({ accessToken: '' }),
+  setAccessToken: (token: string) => {
+    set({ accessToken: token });
+  },
+  deleteAccessToken: () => set({ accessToken: '' }),
 }));
 
 export default useAuth;

--- a/src/stores/userInfo.ts
+++ b/src/stores/userInfo.ts
@@ -1,0 +1,56 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type UserNotTokenItem = {
+  _id: number;
+  email: string;
+  name: string;
+  phone: string;
+  address: string;
+  type: string;
+  createdAt: string;
+  updatedAt: string;
+  extra: {};
+};
+
+export type UserInfo = {
+  userInfo: UserNotTokenItem;
+  setUserInfo: (userInfo: UserNotTokenItem) => void;
+  deleteUserInfo: () => void;
+};
+
+const defaultState: UserNotTokenItem = {
+  _id: 0,
+  email: '',
+  name: '',
+  phone: '',
+  address: '',
+  type: '',
+  createdAt: '',
+  updatedAt: '',
+  extra: {},
+};
+
+/**
+ * 유저의 전체 데이터
+ */
+const useUserInfo = create(
+  persist<UserInfo>(
+    set => ({
+      userInfo: defaultState,
+      setUserInfo: (userInfo: UserNotTokenItem) => {
+        set({ userInfo });
+      },
+      deleteUserInfo: () => {
+        set({ userInfo: defaultState });
+        localStorage.clear();
+      },
+    }),
+    {
+      name: 'user-info',
+      getStorage: () => localStorage, // 로컬 스토리지 사용
+    },
+  ),
+);
+
+export default useUserInfo;


### PR DESCRIPTION
## ✨ 구현기능 

- axios header에 accessToken 설정 완료하였습니다.
- 이제는 Cookie에서 token을 get하여 사용하지 않습니다.
- userInfo를 zustand에 항상 저장하는 기능을 구현하였습니다.

<br>

## 👀 구현한 기능에 대한 gif 

- 

<br>

## 🙏 To Reviewers 🙏

- 앞으로 api 통신은 edutubeAxios를 사용하여 통신해주시기 바랍니다.
- nav, menu 등 user의 타입이나, name등 user data를 기반으로 ui를 바꾸어 보여줘야하는 경우 useUserInfo라는 store를 사용하여 userInfo를 사용해주시기 바랍니다.
- zustand-persist 설치하여 merge, pull 받은 이후 npm i 진행해주시기 바랍니다.
- 현재 Cookie에 저장되어있는 값들은 리팩토링 후 refreshToken을 제외한 나머지 값들은 제거할 예정입니다.(현재는 연관된 코드가 많아 이슈가 발생할 것을 염두해 지우지 않았습니다.

