### PR TITLE
[Refac/149] 예약된 일정 보여주는 부분 로직 수정

### DIFF
--- a/src/components/views/coffeechat/info/CoffeechatCartModal.tsx
+++ b/src/components/views/coffeechat/info/CoffeechatCartModal.tsx
@@ -55,7 +55,7 @@ const CoffeechatCartModal = () => {
           </div>
         </div>
         <div className="flex gap-2 flex-wrap mb-6 justify-center">
-          {coffeechatDetailData?.options.map((item, index: number) => (
+          {coffeechatDetailData?.options?.item?.map((item, index: number) => (
             <p
               key={index}
               className={` border-2 border-solid border-light-main rounded-lg p-2 cursor-pointer hover:bg-light-main minWidth-44  flex   ${item._id === selectedDatetimeId ? 'bg-light-main' : 'hover:bg-gray-200'

--- a/src/components/views/coffeechat/info/CoffeechatCartModal.tsx
+++ b/src/components/views/coffeechat/info/CoffeechatCartModal.tsx
@@ -1,11 +1,13 @@
 'use client';
 import Button from '@/components/atom/Button';
+import { formatDate, formatTime } from '@/helper/utils/datetime';
 import useCreateCoffeechatCart from '@/queries/coffeechat/cart/useCreateCoffeechatCart';
 import useSelectCoffeechatInfo from '@/queries/coffeechat/info/useSelectCoffeechatInfo';
 import { faCircleXmark } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useParams, useRouter } from 'next/navigation';
 import { useState } from 'react';
+
 
 const CoffeechatCartModal = () => {
   const router = useRouter();
@@ -55,27 +57,29 @@ const CoffeechatCartModal = () => {
           </div>
         </div>
         <div className="flex gap-2 flex-wrap mb-6 justify-center">
-          {coffeechatDetailData?.options?.item?.map((item, index: number) => (
-            <p
-              key={index}
-              className={` border-2 border-solid border-light-main rounded-lg p-2 cursor-pointer hover:bg-light-main minWidth-44  flex   ${item._id === selectedDatetimeId ? 'bg-light-main' : 'hover:bg-gray-200'
-                }`}
-              onClick={() => handleDatetimeClick(item._id)}
-            >
+          {coffeechatDetailData?.options?.item
+            ?.filter(item => item.buyQuantity === 0)
+            .map((item, index: number) => (
               <p
-                className={`text-gray-700 leading-6 mr-2 ${item._id === selectedDatetimeId ? 'text-white' : ''
+                key={index}
+                className={` border-2 border-solid border-light-main rounded-lg p-2 cursor-pointer hover:bg-light-main minWidth-44 flex ${item._id === selectedDatetimeId ? 'bg-light-main' : 'hover:bg-gray-200'
                   }`}
+                onClick={() => handleDatetimeClick(item._id)}
               >
-                {JSON.stringify(item.extra.datetime.date).slice(1, 11)}&nbsp;/
+                <p
+                  className={`text-gray-700 leading-6 mr-2 ${item._id === selectedDatetimeId ? 'text-white' : ''
+                    }`}
+                >
+                  {formatDate(item.extra.datetime.date)}&nbsp;
+                </p>
+                <p
+                  className={`text-gray-700 leading-6 ${item._id === selectedDatetimeId ? 'text-white' : ''
+                    }`}
+                >
+                  {formatTime(item.extra.datetime.time)}
+                </p>
               </p>
-              <p
-                className={`text-gray-700 leading-6 ${item._id === selectedDatetimeId ? 'text-white' : ''
-                  }`}
-              >
-                {JSON.stringify(item.extra.datetime.time).slice(12, 17)}
-              </p>
-            </p>
-          ))}
+            ))}
         </div>
         <Button
           content="장바구니"

--- a/src/components/views/coffeechat/info/CoffeechatInfo.tsx
+++ b/src/components/views/coffeechat/info/CoffeechatInfo.tsx
@@ -17,25 +17,13 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { formatDate, formatTime } from '@/helper/utils/datetime';
 
-// type Datetime = {
-//   date: string;
-//   time: string;
-// };
-
 const CoffeechatInfo = ({ _id }: { _id: string }) => {
   const router = useRouter();
   const { data: coffeechatDetailData } = useSelectCoffeechatInfo(_id);
   const { data: replyListData } = useSelectReply(_id);
   const { userInfo } = useUserInfo(store => store);
-  // const [selectedDatetimeList, setSelectedDateTimeList] = useState<Datetime[]>();
   const [isReservationEnabled, setIsReservationEnabled] = useState(true);
   const replyCount = replyListData?.length || 0;
-
-  // useEffect(() => {
-  //   {
-  //     coffeechatDetailData?.options && setSelectedDateTimeList(coffeechatDetailData?.options?.map(item => item.extra.datetime))
-  //   };
-  // }, [coffeechatDetailData]);
 
   useEffect(() => {
     const handleScroll = (e: Event) => {

--- a/src/components/views/coffeechat/info/CoffeechatInfo.tsx
+++ b/src/components/views/coffeechat/info/CoffeechatInfo.tsx
@@ -58,7 +58,7 @@ const CoffeechatInfo = ({ _id }: { _id: string }) => {
   }, []);
 
   useEffect(() => {
-    setIsReservationEnabled(coffeechatDetailData?.options.item.length !== 0);
+    setIsReservationEnabled(coffeechatDetailData?.options.item.filter(item => item.buyQuantity === 0).length !== 0);
   }, [coffeechatDetailData]);
 
   const calculateAverageRating = () => {

--- a/src/components/views/coffeechat/info/CoffeechatInfo.tsx
+++ b/src/components/views/coffeechat/info/CoffeechatInfo.tsx
@@ -32,9 +32,11 @@ const CoffeechatInfo = ({ _id }: { _id: string }) => {
 
   const replyCount = replyListData?.length || 0;
 
-  useEffect(() => {
-    setSelectedDateTimeList(coffeechatDetailData?.options?.map(item => item.extra.datetime));
-  }, [coffeechatDetailData]);
+  // useEffect(() => {
+  //   {
+  //     coffeechatDetailData?.options && setSelectedDateTimeList(coffeechatDetailData?.options?.map(item => item.extra.datetime))
+  //   };
+  // }, [coffeechatDetailData]);
 
   useEffect(() => {
     const handleScroll = (e: Event) => {
@@ -69,7 +71,7 @@ const CoffeechatInfo = ({ _id }: { _id: string }) => {
     if (Number.isInteger(averageRating)) {
       return averageRating; // 소수점 없는 경우 자연수 반환
     } else {
-      return averageRating.toFixed(1); // 소수점 둘째 자리까지 보여주기
+      return parseFloat(averageRating.toFixed(1));; // 소수점 둘째 자리까지 보여주기
     }
   }
 
@@ -208,10 +210,10 @@ const CoffeechatInfo = ({ _id }: { _id: string }) => {
             )}
           </div>
           <div id="review" className="mb-6">
-            <p className="flex gap-2">
+            <div className="flex gap-2">
               <h3 className="text-lg font-bold mb-2">수강생 후기</h3>
               <span className="text-lg font-medium text-light-main">{replyCount}개</span>
-            </p>
+            </div>
             <p className="text-gray-700 text-sm">참여자들이 직접 작성한 후기입니다. </p>
             <RatingSummary
               averageRating={averageRating}

--- a/src/components/views/coffeechat/info/CoffeechatInfo.tsx
+++ b/src/components/views/coffeechat/info/CoffeechatInfo.tsx
@@ -15,21 +15,20 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import { formatDate, formatTime } from '@/helper/utils/datetime';
 
-type Datetime = {
-  date: string;
-  time: string;
-};
+// type Datetime = {
+//   date: string;
+//   time: string;
+// };
 
 const CoffeechatInfo = ({ _id }: { _id: string }) => {
   const router = useRouter();
   const { data: coffeechatDetailData } = useSelectCoffeechatInfo(_id);
   const { data: replyListData } = useSelectReply(_id);
   const { userInfo } = useUserInfo(store => store);
-  const [selectedDatetimeList, setSelectedDateTimeList] = useState<Datetime[]>();
+  // const [selectedDatetimeList, setSelectedDateTimeList] = useState<Datetime[]>();
   const [isReservationEnabled, setIsReservationEnabled] = useState(true);
-  const stringifySelectedDatetimeList = selectedDatetimeList?.map(item => JSON.stringify(item));
-
   const replyCount = replyListData?.length || 0;
 
   // useEffect(() => {
@@ -59,7 +58,7 @@ const CoffeechatInfo = ({ _id }: { _id: string }) => {
   }, []);
 
   useEffect(() => {
-    setIsReservationEnabled(coffeechatDetailData?.options.length !== 0);
+    setIsReservationEnabled(coffeechatDetailData?.options.item.length !== 0);
   }, [coffeechatDetailData]);
 
   const calculateAverageRating = () => {
@@ -186,17 +185,16 @@ const CoffeechatInfo = ({ _id }: { _id: string }) => {
           <div id="schedule" className="mb-6 ">
             <h3 className="text-lg font-bold mb-4">일정</h3>
             <div className="flex flex-wrap">
-              {coffeechatDetailData?.extra.datetimeList?.map((item: Datetime, index: number) => (
+              {coffeechatDetailData?.options?.item?.map((item: any, index: number) => (
                 <p
                   key={index}
-                  className={`mb-2 mr-2 rounded-lg p-2.5 w-44 text-white ${stringifySelectedDatetimeList?.includes(JSON.stringify(item))
+                  className={`mb-2 mr-2 rounded-lg p-2.5 w-36 text-center text-white ${item.buyQuantity == 0
                     ? 'bg-light-main'
                     : 'bg-light-disabled text-gray-100'
                     }`}
                 >
-                  <span className=" mr-2">{JSON.stringify(item.date).slice(1, 11)}</span>
-                  <span className=" mr-2">|</span>
-                  <span>{JSON.stringify(item.time).slice(12, 17)}</span>
+                  <p className=" mr-2">{formatDate(item.extra.datetime.date)}</p>
+                  <p>{formatTime(item.extra.datetime.time)}</p>
                 </p>
               ))}
             </div>

--- a/src/components/views/coffeechat/info/CoffeechatModal.tsx
+++ b/src/components/views/coffeechat/info/CoffeechatModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 import Button from '@/components/atom/Button';
 import { OrderData } from '@/helper/types/order';
+import { formatDate, formatTime } from '@/helper/utils/datetime';
 import useSelectCoffeechatInfo from '@/queries/coffeechat/info/useSelectCoffeechatInfo';
 import useUpdateOrder from '@/queries/coffeechat/order/useUpdateOrder';
 import useUserInfo from '@/stores/userInfo';
@@ -90,27 +91,29 @@ const CoffeechatModal = () => {
           </div>
         </div>
         <div className="flex gap-2 flex-wrap mt-12 mb-12 justify-center">
-          {coffeechatDetailData?.options?.item?.map((item, index: number) => (
-            <p
-              key={index}
-              className={` border-2 border-solid border-light-main rounded-lg p-2 cursor-pointer hover:bg-light-main minWidth-44  flex   ${item._id === selectedDatetimeId ? 'bg-light-main' : 'hover:bg-gray-200'
-                }`}
-              onClick={() => handleDatetimeClick(item._id)}
-            >
+          {coffeechatDetailData?.options?.item
+            ?.filter(item => item.buyQuantity === 0)
+            .map((item, index: number) => (
               <p
-                className={`text-gray-700 leading-6 mr-2 ${item._id === selectedDatetimeId ? 'text-white' : ''
+                key={index}
+                className={` border-2 border-solid border-light-main rounded-lg p-2 cursor-pointer hover:bg-light-main minWidth-44 flex ${item._id === selectedDatetimeId ? 'bg-light-main' : 'hover:bg-gray-200'
                   }`}
+                onClick={() => handleDatetimeClick(item._id)}
               >
-                {JSON.stringify(item.extra.datetime.date).slice(1, 11)}&nbsp;/
+                <p
+                  className={`text-gray-700 leading-6 mr-2 ${item._id === selectedDatetimeId ? 'text-white' : ''
+                    }`}
+                >
+                  {formatDate(item.extra.datetime.date)}&nbsp;
+                </p>
+                <p
+                  className={`text-gray-700 leading-6 ${item._id === selectedDatetimeId ? 'text-white' : ''
+                    }`}
+                >
+                  {formatTime(item.extra.datetime.time)}
+                </p>
               </p>
-              <p
-                className={`text-gray-700 leading-6 ${item._id === selectedDatetimeId ? 'text-white' : ''
-                  }`}
-              >
-                {JSON.stringify(item.extra.datetime.time).slice(12, 17)}
-              </p>
-            </p>
-          ))}
+            ))}
         </div>
         <div className="mt-6 mb-6">
           <section className="flex flex-col gap-2">

--- a/src/components/views/coffeechat/info/CoffeechatModal.tsx
+++ b/src/components/views/coffeechat/info/CoffeechatModal.tsx
@@ -90,7 +90,7 @@ const CoffeechatModal = () => {
           </div>
         </div>
         <div className="flex gap-2 flex-wrap mt-12 mb-12 justify-center">
-          {coffeechatDetailData?.options.map((item, index: number) => (
+          {coffeechatDetailData?.options?.item?.map((item, index: number) => (
             <p
               key={index}
               className={` border-2 border-solid border-light-main rounded-lg p-2 cursor-pointer hover:bg-light-main minWidth-44  flex   ${item._id === selectedDatetimeId ? 'bg-light-main' : 'hover:bg-gray-200'

--- a/src/queries/coffeechat/info/useSelectCoffeechatInfo.tsx
+++ b/src/queries/coffeechat/info/useSelectCoffeechatInfo.tsx
@@ -75,7 +75,7 @@ type ProductItem = {
   updatedAt: string;
   replies: [];
   bookmarks: [];
-  options: Options[];
+  options: { item: Options[] };
 };
 
 const useSelectCoffeechatInfo = (_id: string) => {


### PR DESCRIPTION
## ✨ 구현기능 

- 이전에는 백엔드 쪽에서 구매된 상품은 options 배열에서 제거가 된 채로 데이터가 넘어왔으나 현재는 구매된 상품, 구매 안된 상품 모두 options 배열로 넘어와서 buyQuantity 값 여부에 따라 예약여부를 확인할 수 있도록 프론트엔드 로직 수정
- util/formatDate, formatTime 함수 사용하여 date 데이터 필터링
- 변경된 로직에 따라 장바구니, 예약하기 버튼 disabled 조건 변경
- tofixed로 처리한 값은 문자열로 취급되어서 tofixed 사용한 값 앞에 parseFloat 적용하여 number로 변경
- options배열 내부에 Item 값을 들어가야 child product값에 접근할 수 있어 데이터 접근하는 depth 수정

<br>

## 👀 구현한 기능에 대한 gif 

-
![스크린샷 2023-12-19 오후 5 49 30](https://github.com/FESPfinal/EDUTUBE/assets/78894678/e49cf719-80ee-414f-9e17-ca463c0647b1)
![스크린샷 2023-12-19 오후 5 50 04](https://github.com/FESPfinal/EDUTUBE/assets/78894678/857ff02a-640b-478b-8b69-8be750cad229)


<br>

## 🙏 To Reviewers 🙏

-

close #149 
