### PR TITLE
[Feat/192]: 커피챗 리스트 페이지 무한 스크롤 구현

### DIFF
--- a/app/coffeechat/page.tsx
+++ b/app/coffeechat/page.tsx
@@ -1,6 +1,6 @@
 import CoffeechatLists from '../../src/components/views/coffeechat/CoffeechatLists';
 
-const URL = `${process.env.NEXT_PUBLIC_EDUTUBE_API}/products?page=1&limit=1`;
+const URL = `${process.env.NEXT_PUBLIC_EDUTUBE_API}/products?page=1&limit=12`;
 
 async function getData() {
   const res = await fetch(URL, { cache: 'no-store' });

--- a/app/coffeechat/page.tsx
+++ b/app/coffeechat/page.tsx
@@ -1,13 +1,12 @@
 import CoffeechatLists from '../../src/components/views/coffeechat/CoffeechatLists';
 
-const URL = `${process.env.NEXT_PUBLIC_EDUTUBE_API}/products`;
+const URL = `${process.env.NEXT_PUBLIC_EDUTUBE_API}/products?page=1&limit=1`;
 
 async function getData() {
   const res = await fetch(URL, { cache: 'no-store' });
   if (!res.ok) {
     throw new Error('Failed to fetch data');
   }
-
   return res.json();
 }
 

--- a/src/components/views/coffeechat/CoffeechatLists.tsx
+++ b/src/components/views/coffeechat/CoffeechatLists.tsx
@@ -17,6 +17,7 @@ interface Props {
 const CoffeechatLists = ({ initData }: Props) => {
   const { mutate: searchMutate } = useSelectCoffeechatSearch();
   const { data: coffeechatListData,
+    isLoading,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage, } = useSelectInfiniteCoffeechatList();
@@ -190,25 +191,28 @@ const CoffeechatLists = ({ initData }: Props) => {
         // TODO: 검색 결과 없는 이미지 추가
         <p className="mt-20 text-center text-xl text-gray-500">검색 결과가 없습니다.</p>
       )}
-      {/* <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-        {allCoffeechatList.map((item: any) => (
-          <CoffeechatItem key={item._id} item={item} />
-        ))}
-      </ul> */}
-      <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4" >
-        {coffeechatListData && coffeechatListData.pages.map((group, i) => (
-          <React.Fragment key={i}>
-            {group?.map((item: any) => (
-              <CoffeechatItem key={item._id} item={item} />
+      {isLoading ?
+        (<ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+          {coffeechatList.map((item: any) => (
+            <CoffeechatItem key={item._id} item={item} />
+          ))}
+        </ul>) : (
+          <div><ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4" >
+            {coffeechatListData && coffeechatListData.pages.map((group, i) => (
+              <React.Fragment key={i}>
+                {group?.map((item: any) => (
+                  <CoffeechatItem key={item._id} item={item} />
+                ))}
+              </React.Fragment>
             ))}
-          </React.Fragment>
-        ))}
-      </ul>
-      <div ref={loadMoreRef} className="flex justify-center items-center mt-10">
-        {isFetchingNextPage ? (
-          <div className="w-6 h-6 border-t-4 border-light-main rounded-full animate-spin-slow" />
-        ) : null}
-      </div>
+          </ul>
+            <div ref={loadMoreRef} className="flex justify-center items-center mt-10">
+              {isFetchingNextPage ? (
+                <div className="w-6 h-6 border-t-4 border-light-main rounded-full animate-spin-slow" />
+              ) : null}
+            </div>
+          </div>)
+      }
     </>
   );
 };

--- a/src/queries/coffeechat/useSelectInfiniteCoffeechatList.tsx
+++ b/src/queries/coffeechat/useSelectInfiniteCoffeechatList.tsx
@@ -35,7 +35,7 @@ export type CoffeechatItem = {
 
 export type CoffeechatList = CoffeechatItem[];
 
-const URL = (pageParam: number) => `/products?page=${pageParam}&limit=3`;
+const URL = (pageParam: number) => `/products?page=${pageParam}&limit=12`;
 
 const useSelectInfiniteCoffeechatList = () => {
   const { edutubeAxios } = useEdutubeAxios();
@@ -45,7 +45,7 @@ const useSelectInfiniteCoffeechatList = () => {
     return response.data.item as CoffeechatList;
   };
 
-  const { data, fetchNextPage, isFetchingNextPage, hasNextPage } = useInfiniteQuery({
+  const { data, fetchNextPage, isFetchingNextPage, hasNextPage, isLoading } = useInfiniteQuery({
     queryKey: ['coffeechatList'],
     queryFn: ({ pageParam }) => axiosGet(pageParam),
     initialPageParam: 1,
@@ -56,7 +56,7 @@ const useSelectInfiniteCoffeechatList = () => {
       return lastPageParam + 1;
     },
   });
-  return { data, fetchNextPage, isFetchingNextPage, hasNextPage };
+  return { data, isLoading, fetchNextPage, isFetchingNextPage, hasNextPage };
 };
 
 

--- a/src/queries/coffeechat/useSelectInfiniteCoffeechatList.tsx
+++ b/src/queries/coffeechat/useSelectInfiniteCoffeechatList.tsx
@@ -1,0 +1,63 @@
+import useEdutubeAxios from '@/helper/utils/useEdutubeAxios';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+export type CoffeechatItem = {
+  _id: number;
+  mainImages: string[];
+  name: string;
+  price: number;
+  shippingFees: number;
+  show: boolean;
+  active: boolean;
+  quantity: number;
+  buyQuantity: number;
+  extra: {
+    intro: string;
+    place: string;
+    online: string;
+    offline: string;
+    datetimeList: {
+      date: string;
+      time: string;
+    }[];
+    author: string;
+    authorImage: string;
+    type: string;
+    jobCategory: string[];
+    regionCategory: string;
+    productType: string;
+    depth: number;
+  };
+  seller_id: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CoffeechatList = CoffeechatItem[];
+
+const URL = (pageParam: number) => `/products?page=${pageParam}&limit=3`;
+
+const useSelectInfiniteCoffeechatList = () => {
+  const { edutubeAxios } = useEdutubeAxios();
+
+  const axiosGet = async (pageParam: any) => {
+    const response = await edutubeAxios.get(URL(pageParam));
+    return response.data.item as CoffeechatList;
+  };
+
+  const { data, fetchNextPage, isFetchingNextPage, hasNextPage } = useInfiniteQuery({
+    queryKey: ['coffeechatList'],
+    queryFn: ({ pageParam }) => axiosGet(pageParam),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, allPages, lastPageParam) => {
+      if (lastPage?.length === 0) {
+        return null;
+      }
+      return lastPageParam + 1;
+    },
+  });
+  return { data, fetchNextPage, isFetchingNextPage, hasNextPage };
+};
+
+
+export default useSelectInfiniteCoffeechatList;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -43,9 +43,18 @@ module.exports = {
             borderColor: 'white',
           },
         },
+        spin: {
+          '0%': {
+            transform: 'rotate(0deg)'
+          },
+          '100%': {
+            transform: 'rotate(360deg)'
+          },
+        },
       },
       animation: {
         typing: 'typing 2s steps(20) infinite alternate, blink .7s infinite',
+        'spin-slow': 'spin 3s linear infinite',
       },
     },
   },


### PR DESCRIPTION
## ✨ 구현기능 

- 커피챗 리스트 페이지 무한 스크롤 구현
- react-query내부에 있는 infiniteQuery 사용해서 구현
- IntersectionObserver 사용해서 하단 페이지에 닿음 감지하고 다음 페이지에 있는 데이터 불러오도록 구현
- 한번에 가져올 때 게시물 12개 단위로 가져오기
- 게시물 데이터 loading 중일 땐 loading 중 표시
- 초기 데이터 12개 SSR에서 미리 불러오고, 이후에 SSR에서 데이터 불러오기 완료되었으면 SSR데이터로 보여주도록 구현

<br>

## 👀 구현한 기능에 대한 gif 

-
![infniteScroll2](https://github.com/FESPfinal/EDUTUBE/assets/78894678/21400104-115e-4cb9-a2f2-a5cdb5f7c6e2)


<br>

## 🙏 To Reviewers 🙏

- 웹 페이지에서 한 줄에 4개씩 들어가고 큰 뷰에서 최대 2줄반까지 보여서 초기 로딩 데이터 12개로 설정해서 구현했습니다. 개수 의견 주세요~
- 구현 기능 Gif에서는 이해를 돕기 위해서 3개 단위로 잘라서 다음 데이터 로딩 보여주도록 하였음

close #192 